### PR TITLE
Extends TRISA test coverage

### DIFF
--- a/pkg/iso3166/alpha_test.go
+++ b/pkg/iso3166/alpha_test.go
@@ -39,6 +39,9 @@ func TestFind(t *testing.T) {
 
 	_, err = iso3166.Find("Foo")
 	require.Error(t, err)
+
+	_, err = iso3166.Find("turk")
+	require.Contains(t, err.Error(), "ambiguous, multiple countries matched")
 }
 
 func TestNormalizedSearch(t *testing.T) {
@@ -57,4 +60,9 @@ func TestNormalizedSearch(t *testing.T) {
 			require.Equal(t, code.Alpha3, found.Alpha3)
 		}
 	}
+}
+
+func TestList(t *testing.T) {
+	codes := iso3166.List()
+	require.Equal(t, len(codes), 249)
 }

--- a/pkg/iso3166/alpha_test.go
+++ b/pkg/iso3166/alpha_test.go
@@ -64,5 +64,5 @@ func TestNormalizedSearch(t *testing.T) {
 
 func TestList(t *testing.T) {
 	codes := iso3166.List()
-	require.Equal(t, len(codes), 249)
+	require.Equal(t, 249, len(codes))
 }

--- a/pkg/ivms101/ivms101.go
+++ b/pkg/ivms101/ivms101.go
@@ -52,12 +52,12 @@ func (p *NaturalPerson) Validate() (err error) {
 		}
 	}
 
-	// Constraint: optioanl Max50Text
+	// Constraint: optional Max50Text
 	if len(p.CustomerIdentification) > 50 {
 		return ErrInvalidCustomerIdentification
 	}
 
-	// Contstraint: Optional Valid DateAndPlaceOfBirth
+	// Constraint: Optional Valid DateAndPlaceOfBirth
 	if p.DateAndPlaceOfBirth != nil {
 		if err = p.DateAndPlaceOfBirth.Validate(); err != nil {
 			return err
@@ -285,7 +285,7 @@ func (n *LocalLegalPersonNameId) Validate() (err error) {
 	return nil
 }
 
-// Validate the IVMS101 constraints for a geograpic address
+// Validate the IVMS101 constraints for a geographic address
 func (a *Address) Validate() (err error) {
 	// Constraint: valid required address type code
 	typeCode := int32(a.AddressType)

--- a/pkg/ivms101/ivms101_test.go
+++ b/pkg/ivms101/ivms101_test.go
@@ -18,23 +18,219 @@ func TestLegalPerson(t *testing.T) {
 	require.NoError(t, json.Unmarshal(data, &person))
 	require.NoError(t, person.Validate())
 
-	// Should be able to convert a legal person into a generic Persion
+	// Correct name can be validated
+	require.NoError(t, person.Name.Validate())
+
+	// Correctly structured name ids can be validated
+	pid := &ivms101.LegalPersonNameId{
+		LegalPersonName:               person.Name.NameIdentifiers[0].LegalPersonName,
+		LegalPersonNameIdentifierType: person.Name.NameIdentifiers[0].LegalPersonNameIdentifierType,
+	}
+	require.NoError(t, pid.Validate())
+	lpid := &ivms101.LocalLegalPersonNameId{
+		LegalPersonName:               person.Name.NameIdentifiers[0].LegalPersonName,
+		LegalPersonNameIdentifierType: person.Name.NameIdentifiers[0].LegalPersonNameIdentifierType,
+	}
+	require.NoError(t, lpid.Validate())
+
+	// Complete address can be validated
+	addr := &ivms101.Address{
+		AddressType:    person.GeographicAddresses[0].AddressType,
+		BuildingNumber: person.GeographicAddresses[0].BuildingNumber,
+		StreetName:     person.GeographicAddresses[0].StreetName,
+		TownName:       person.GeographicAddresses[0].TownName,
+		PostCode:       person.GeographicAddresses[0].PostBox,
+		Country:        person.GeographicAddresses[0].Country,
+	}
+	require.NoError(t, addr.Validate())
+
+	// Correct national identifier can be validated
+	require.NoError(t, person.NationalIdentification.Validate())
+
+	// Should be able to convert a legal person into a generic Person
 	gp := person.Person()
 	require.Nil(t, gp.GetNaturalPerson())
 	require.Equal(t, person, gp.GetLegalPerson())
+
+	// Failure cases
+	// Person with missing data should not produce a valid legal person
+	notaperson := &ivms101.LegalPerson{}
+	require.Error(t, notaperson.Validate())
+
+	// Name with no identifiers can't be validated
+	notaname := &ivms101.LegalPersonName{}
+	require.Error(t, notaname.Validate())
+
+	// Name missing type can't be validated
+	noType := &ivms101.LegalPersonNameId{LegalPersonName: "Bob's Discount VASP, PLC"}
+	notaname.NameIdentifiers = append(notaname.NameIdentifiers, noType)
+	require.Error(t, notaname.Validate())
+
+	// Incomplete name identifiers can't be validated
+	pidBad := &ivms101.LegalPersonNameId{LegalPersonNameIdentifierType: 1}
+	require.Error(t, pidBad.Validate())
+	lpidBad := &ivms101.LocalLegalPersonNameId{LegalPersonNameIdentifierType: 1}
+	require.Error(t, lpidBad.Validate())
+
+	// Address with bad type can't be validated
+	typeBad := &ivms101.Address{
+		AddressType:    100000000,
+		BuildingNumber: person.GeographicAddresses[0].BuildingNumber,
+		StreetName:     person.GeographicAddresses[0].StreetName,
+		TownName:       person.GeographicAddresses[0].TownName,
+		PostCode:       person.GeographicAddresses[0].PostBox,
+		Country:        person.GeographicAddresses[0].Country,
+	}
+	require.Error(t, typeBad.Validate())
+
+	// Address with bad country can't be validated
+	countryBad := &ivms101.Address{
+		AddressType:    person.GeographicAddresses[0].AddressType,
+		BuildingNumber: person.GeographicAddresses[0].BuildingNumber,
+		StreetName:     person.GeographicAddresses[0].StreetName,
+		TownName:       person.GeographicAddresses[0].TownName,
+		PostCode:       person.GeographicAddresses[0].PostBox,
+		Country:        "Lunar",
+	}
+	require.Error(t, countryBad.Validate())
+
+	// Address with too many address lines can't be validated
+	lines := []string{
+		"123", "street", "lane", "road", "house", "cottage", "place", "usa",
+	}
+	linesBad := &ivms101.Address{
+		AddressType: person.GeographicAddresses[0].AddressType,
+		Country:     person.GeographicAddresses[0].Country,
+		AddressLine: lines,
+	}
+	require.Error(t, linesBad.Validate())
+
+	// Street is required if no address lines are provided
+	noStreet := &ivms101.Address{
+		AddressType:    person.GeographicAddresses[0].AddressType,
+		BuildingNumber: person.GeographicAddresses[0].BuildingNumber,
+		TownName:       person.GeographicAddresses[0].TownName,
+		PostCode:       person.GeographicAddresses[0].PostBox,
+		Country:        person.GeographicAddresses[0].Country,
+	}
+	require.Error(t, noStreet.Validate())
+
+	// No national identification can't be validated
+	noNid := &ivms101.NationalIdentification{NationalIdentifier: ""}
+	require.Error(t, noNid.Validate())
+
+	// Overlong national identification can't be validated
+	longNid := &ivms101.NationalIdentification{
+		NationalIdentifier:     "2343456987GHE97777342KIWERPM000000021287319636021864HT7450913054",
+		NationalIdentifierType: 9,
+		CountryOfIssue:         "GB",
+		RegistrationAuthority:  "RA000589",
+	}
+	require.Error(t, longNid.Validate())
+
+	// Invalid NID type can't be validated
+	wrongNid := &ivms101.NationalIdentification{
+		NationalIdentifier:     "213800AQUAUP6I215N33",
+		NationalIdentifierType: 1000000000,
+		CountryOfIssue:         "FR",
+		RegistrationAuthority:  "RA000589",
+	}
+	require.Error(t, wrongNid.Validate())
+
+	// Bad code for country of issue can't be validated
+	badCode := &ivms101.NationalIdentification{
+		NationalIdentifier:     "213800AQUAUP6I215N33",
+		NationalIdentifierType: 4,
+		CountryOfIssue:         "America",
+		RegistrationAuthority:  "RA000589",
+	}
+	require.Error(t, badCode.Validate())
 }
 
 func TestNaturalPerson(t *testing.T) {
 	data, err := ioutil.ReadFile("testdata/naturalperson.json")
 	require.NoError(t, err)
 
-	// Should be able to load a valid legal person from JSON data
+	// Should be able to load a valid natural person from JSON data
 	var person *ivms101.NaturalPerson
 	require.NoError(t, json.Unmarshal(data, &person))
 	require.NoError(t, person.Validate())
 
-	// Should be able to convert a legal person into a generic Persion
+	// Correct name can be validated
+	require.NoError(t, person.Name.Validate())
+
+	// Correct DOB can be validated
+	require.NoError(t, person.DateAndPlaceOfBirth.Validate())
+
+	// Correctly structured name ids can be validated
+	pid := &ivms101.NaturalPersonNameId{
+		PrimaryIdentifier:   person.Name.NameIdentifiers[0].PrimaryIdentifier,
+		SecondaryIdentifier: person.Name.NameIdentifiers[0].SecondaryIdentifier,
+		NameIdentifierType:  person.Name.NameIdentifiers[0].NameIdentifierType,
+	}
+	require.NoError(t, pid.Validate())
+	lpid := &ivms101.LocalNaturalPersonNameId{
+		PrimaryIdentifier:   person.Name.NameIdentifiers[0].PrimaryIdentifier,
+		SecondaryIdentifier: person.Name.NameIdentifiers[0].SecondaryIdentifier,
+		NameIdentifierType:  person.Name.NameIdentifiers[0].NameIdentifierType,
+	}
+	require.NoError(t, lpid.Validate())
+
+	// Complete address can be validated
+	addr := &ivms101.Address{
+		AddressType:    person.GeographicAddresses[0].AddressType,
+		BuildingNumber: person.GeographicAddresses[0].BuildingNumber,
+		StreetName:     person.GeographicAddresses[0].StreetName,
+		TownName:       person.GeographicAddresses[0].TownName,
+		PostCode:       person.GeographicAddresses[0].PostBox,
+		Country:        person.GeographicAddresses[0].Country,
+	}
+	require.NoError(t, addr.Validate())
+
+	// Correct national identifier can be validated
+	require.NoError(t, person.NationalIdentification.Validate())
+
+	// Should be able to convert a legal person into a generic Person
 	gp := person.Person()
 	require.Nil(t, gp.GetLegalPerson())
 	require.Equal(t, person, gp.GetNaturalPerson())
+
+	// Failure cases
+	// JSON data missing required fields should not produce a valid natural person
+	notaperson := &ivms101.NaturalPerson{}
+	require.Error(t, notaperson.Validate())
+
+	// Name with no identifiers can't be validated
+	notaname := &ivms101.NaturalPersonName{}
+	require.Error(t, notaname.Validate())
+
+	// Name missing type can't be validated
+	noType := &ivms101.NaturalPersonNameId{
+		PrimaryIdentifier:   "Annie",
+		SecondaryIdentifier: "Oakley",
+	}
+	notaname.NameIdentifiers = append(notaname.NameIdentifiers, noType)
+	require.Error(t, notaname.Validate())
+
+	// Incomplete name identifiers can't be validated
+	pidBad := &ivms101.NaturalPersonNameId{NameIdentifierType: 1}
+	require.Error(t, pidBad.Validate())
+	lpidBad := &ivms101.LocalNaturalPersonNameId{NameIdentifierType: 1}
+	require.Error(t, lpidBad.Validate())
+
+	// No date of birth can't be validated
+	pobOnly := &ivms101.DateAndPlaceOfBirth{PlaceOfBirth: "Champaign, IL"}
+	require.Error(t, pobOnly.Validate())
+
+	// No place of birth can't be validated
+	dobOnly := &ivms101.DateAndPlaceOfBirth{DateOfBirth: "2011-05-21"}
+	require.Error(t, dobOnly.Validate())
+
+	// Date must be parsable or can't be validated
+	badDob := &ivms101.DateAndPlaceOfBirth{DateOfBirth: "80-80-80-80"}
+	require.Error(t, badDob.Validate())
+
+	// Can't be born in the future
+	futureDob := &ivms101.DateAndPlaceOfBirth{DateOfBirth: "8000-05-21"}
+	require.Error(t, futureDob.Validate())
 }

--- a/pkg/trust/trust_test.go
+++ b/pkg/trust/trust_test.go
@@ -77,6 +77,10 @@ func TestPublicProvider(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, pool.Subjects(), 3)
 
+	provPool := trust.NewPool(o)
+	require.Equal(t, provPool[o.String()], o)
+	require.False(t, o.IsPrivate())
+
 	_, err = p.GetKeyPair()
 	require.Error(t, err)
 

--- a/pkg/trust/zip_test.go
+++ b/pkg/trust/zip_test.go
@@ -47,7 +47,7 @@ func TestNewSerializer(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestSeralizer(t *testing.T) {
+func TestSerializer(t *testing.T) {
 	// Test Serializer on Sectigo data, e.g. a client can read a private Provider from
 	// a PCKS12 encrypted file and that the Directory service can extract the Public
 	// keys and write them in a gzip format that can then be decrompressed and loaded by

--- a/pkg/trust/zip_test.go
+++ b/pkg/trust/zip_test.go
@@ -80,6 +80,7 @@ func TestSerializer(t *testing.T) {
 	serializer, err = trust.NewSerializer(false)
 	require.NoError(t, err)
 	provData, err := serializer.Compress(provider.Public())
+	require.NoError(t, err)
 	require.Equal(t, len(provData), 4402)
 
 	// Write public provider to gzip file
@@ -104,6 +105,7 @@ func TestSerializer(t *testing.T) {
 	// Compress provider pool
 	pool := trust.NewPool(provider.Public())
 	poolData, err := serializer.CompressPool(pool)
+	require.NoError(t, err)
 	require.Equal(t, len(poolData), 4402)
 
 	// Write provider pool to gzip file


### PR DESCRIPTION
This PR extends test coverage for TRISA, particularly targeting the `ivms101`, `iso3166`, and `trust` packages.

Additions requested in sc-1520:

## pkg/iso3166

- [x] Find() - Error case for ambiguous match
- [x] Add tests for List()

## pkg/ivms101

- [x] Add constraint (error path) tests for LegalPerson and NaturalPerson
- [x] Add unit tests for Validate() methods on:
    - NaturalPersonName
    - NaturalPersonNameId
    - LocalNaturalPersonNameId
    - LegalPersonName
    - LegalPersonNameId
    - LocalLegalPersonNameId
    - Address
    - NationalIdentification
    - DateAndPlaceofBirth
- [x] Add tests for NaturalPerson.Names(), LegalPerson.Names()

## pkg/trust

- [x] Add unit tests for pool.go (*Note: most of these tests were already implemented in `trust_test.go`, but I added a small test for the ProviderPool functionality*)
- [x] Add unit tests
    - Serializer.ReadPoolFile
    - Serializer.CompressPool
    - Serializer.WritePoolFile
    - Serializer.getFormat (*skipped this one since it's private*)