### PR TITLE
Update rVASP Docs

### DIFF
--- a/docs/content/testnet/rvasps.de.md
+++ b/docs/content/testnet/rvasps.de.md
@@ -76,6 +76,7 @@ $ rvasp transfer -e admin.alice.vaspbot.net:443 \
         -a mary@alicevasp.us \
         -d 0.3 \
         -B trisa.example.com \
+        -b cryptowalletaddress \
         -E
 ```
 
@@ -91,6 +92,7 @@ Um die Protokollpuffer direkt zu nutzen, verwenden Sie den `TRISAIntegration`-Di
 {
     "account": "mary@alicevasp.us",
     "amount": 0.3,
+    "beneficiary": "cryptowalletaddress",
     "beneficiary_vasp": "trisa.example.com",
     "check_beneficiary": false,
     "external_demo": true

--- a/docs/content/testnet/rvasps.en.md
+++ b/docs/content/testnet/rvasps.en.md
@@ -80,7 +80,7 @@ $ rvasp transfer -e admin.alice.vaspbot.net:443 \
         -E
 ```
 
-This message sends the Alice rVASP a message using the `-e` or `--endpoint` flag, and specifies that the originating account should be "mary@alicevasp.us" using the `-a` or `--account` flag. The originating account is used to determine what IVMS101 data to send to the beneficiary. The `-d` or `--amount` flag specifies the amount of "AliceCoin" to send. Finally, the `-b` or `--beneficiary` flag specifies the crypto wallet address of the beneficiary you'd like to receive.
+This message sends the Alice rVASP a message using the `-e` or `--endpoint` flag, and specifies that the originating account should be "mary@alicevasp.us" using the `-a` or `--account` flag. The originating account is used to determine what IVMS101 data to send to the beneficiary. The `-d` or `--amount` flag specifies the amount of "AliceCoin" to send. Finally, the `-b` or `--beneficiary` flag specifies the crypto wallet address of the beneficiary you intend as the recipient.
 
 The next two parts are critical. The `-E` or `--external-demo` flag tells the rVASP to trigger a request to your service rather than to perform a demo exchange with another rVASP. This flag is required! Finally, the `-B` or `--beneficiary-vasp` flag specifies where the rVASP will send the request. This field should be able to be looked up in the TRISA TestNet directory service; e.g. it should be your common name or the name of your VASP if it is searchable.
 

--- a/docs/content/testnet/rvasps.en.md
+++ b/docs/content/testnet/rvasps.en.md
@@ -76,10 +76,11 @@ $ rvasp transfer -e admin.alice.vaspbot.net:443 \
         -a mary@alicevasp.us \
         -d 0.3 \
         -B trisa.example.com \
+        -b cryptowalletaddress \
         -E
 ```
 
-This message sends the Alice rVASP a message using the `-e` or `--endpoint` flag, and specifies that the originating account should be "mary@alicevasp.us" using the `-a` or `--account` flag. The originating account is used to determine what IVMS101 data to send to the beneficiary. The `-d` or `--amount` flag specifies the amount of "AliceCoin" to send.
+This message sends the Alice rVASP a message using the `-e` or `--endpoint` flag, and specifies that the originating account should be "mary@alicevasp.us" using the `-a` or `--account` flag. The originating account is used to determine what IVMS101 data to send to the beneficiary. The `-d` or `--amount` flag specifies the amount of "AliceCoin" to send. Finally, the `-b` or `--beneficiary` flag specifies the crypto wallet address of the beneficiary you'd like to receive.
 
 The next two parts are critical. The `-E` or `--external-demo` flag tells the rVASP to trigger a request to your service rather than to perform a demo exchange with another rVASP. This flag is required! Finally, the `-B` or `--beneficiary-vasp` flag specifies where the rVASP will send the request. This field should be able to be looked up in the TRISA TestNet directory service; e.g. it should be your common name or the name of your VASP if it is searchable.
 
@@ -91,6 +92,7 @@ To use the protocol buffers directly, use the `TRISAIntegration` service `Transf
 {
     "account": "mary@alicevasp.us",
     "amount": 0.3,
+    "beneficiary": "cryptowalletaddress",
     "beneficiary_vasp": "trisa.example.com",
     "check_beneficiary": false,
     "external_demo": true

--- a/docs/content/testnet/rvasps.fr.md
+++ b/docs/content/testnet/rvasps.fr.md
@@ -76,6 +76,7 @@ $ rvasp transfer -e admin.alice.vaspbot.net:443 \
         -a mary@alicevasp.us \
         -d 0.3 \
         -B trisa.example.com \
+        -b cryptowalletaddress \
         -E
 ```
 
@@ -91,6 +92,7 @@ Pour utiliser directement les tampons de protocole, utilisez le `TRISAIntegratio
 {
     "account": "mary@alicevasp.us",
     "amount": 0.3,
+    "beneficiary": "cryptowalletaddress",
     "beneficiary_vasp": "trisa.example.com",
     "check_beneficiary": false,
     "external_demo": true

--- a/docs/content/testnet/rvasps.ja.md
+++ b/docs/content/testnet/rvasps.ja.md
@@ -76,6 +76,7 @@ $ rvasp transfer -e admin.alice.vaspbot.net:443 \
         -a mary@alicevasp.us \
         -d 0.3 \
         -B trisa.example.com \
+        -b cryptowalletaddress \
         -E
 ```
 
@@ -91,6 +92,7 @@ $ rvasp transfer -e admin.alice.vaspbot.net:443 \
 {
     "account": "mary@alicevasp.us",
     "amount": 0.3,
+    "beneficiary": "cryptowalletaddress",
     "beneficiary_vasp": "trisa.example.com",
     "check_beneficiary": false,
     "external_demo": true

--- a/docs/content/testnet/rvasps.zh.md
+++ b/docs/content/testnet/rvasps.zh.md
@@ -76,6 +76,7 @@ $ rvasp transfer -e admin.alice.vaspbot.net:443 \
         -a mary@alicevasp.us \
         -d 0.3 \
         -B trisa.example.com \
+        -b cryptowalletaddress \
         -E
 ```
 
@@ -91,6 +92,7 @@ $ rvasp transfer -e admin.alice.vaspbot.net:443 \
 {
     "account": "mary@alicevasp.us",
     "amount": 0.3,
+    "beneficiary": "cryptowalletaddress",
     "beneficiary_vasp": "trisa.example.com",
     "check_beneficiary": false,
     "external_demo": true


### PR DESCRIPTION
The documentation of the rVASP command should include `-b` flag to send a beneficiary wallet address with the transfer request so the remote VASP can verify it. I've updated all of the translations with the code snippet, but only the english translation with a text description of what's happening.

@tl6kk this might be an interesting case for Rumi! 