### PR TITLE
sc-2445 add envelope and mtls tests

### DIFF
--- a/pkg/trisa/handler/handler.go
+++ b/pkg/trisa/handler/handler.go
@@ -50,6 +50,10 @@ func Open(in *protocol.SecureEnvelope, key interface{}) (_ *Envelope, err error)
 		payloadData   []byte
 	)
 
+	if in == nil {
+		return nil, protocol.Errorf(protocol.BadRequest, "missing secure envelope")
+	}
+
 	// Check the algorithms to make sure they're supported
 	// TODO: allow more algorithms than just AES256-GCM and HMAC-SHA256
 	if in.EncryptionAlgorithm != "AES256-GCM" {

--- a/pkg/trisa/handler/handler_test.go
+++ b/pkg/trisa/handler/handler_test.go
@@ -1,0 +1,97 @@
+package handler_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trisacrypto/trisa/pkg/ivms101"
+	protocol "github.com/trisacrypto/trisa/pkg/trisa/api/v1beta1"
+	"github.com/trisacrypto/trisa/pkg/trisa/handler"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+// TestEnvelope tests that the Envelope Seal and Open operations work correctly.
+func TestEnvelope(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	publicKey := &privateKey.PublicKey
+
+	// Create a new Envelope with a payload
+	payload := &protocol.Payload{
+		Identity: &anypb.Any{},
+	}
+	identity := &ivms101.LegalPerson{
+		Name: &ivms101.LegalPersonName{
+			NameIdentifiers: []*ivms101.LegalPersonNameId{
+				{
+					LegalPersonName:               "John Doe",
+					LegalPersonNameIdentifierType: ivms101.LegalPersonLegal,
+				},
+			},
+		},
+	}
+	anypb.MarshalFrom(payload.Identity, identity, proto.MarshalOptions{})
+	envelope := handler.New("", payload, nil)
+	require.NotNil(t, envelope)
+	require.NotEmpty(t, envelope.ID)
+	require.NotNil(t, envelope.Payload)
+	require.NotNil(t, envelope.Cipher)
+
+	// Fail to seal the envelope with an unsupported key type
+	_, err = envelope.Seal(nil)
+	require.Error(t, err)
+	_, err = envelope.Seal(privateKey)
+	require.Error(t, err)
+
+	// Seal the envelope with an RSA key
+	secure, err := envelope.Seal(publicKey)
+	require.NoError(t, err)
+	require.NotNil(t, secure)
+	require.Equal(t, envelope.ID, secure.Id)
+	require.Equal(t, envelope.Cipher.EncryptionAlgorithm(), secure.EncryptionAlgorithm)
+	require.Equal(t, envelope.Cipher.SignatureAlgorithm(), secure.HmacAlgorithm)
+	require.NotEmpty(t, secure.Payload)
+	require.NotEmpty(t, secure.Hmac)
+	require.NotEmpty(t, secure.EncryptionKey)
+	require.NotEmpty(t, secure.HmacSecret)
+
+	// Fail to open a nil envelope
+	_, err = handler.Open(nil, privateKey)
+	require.Error(t, err)
+
+	// Fail to open an envelope with an invalid encryption algorithm
+	secure.EncryptionAlgorithm = "invalid"
+	_, err = handler.Open(secure, privateKey)
+	require.Error(t, err)
+
+	// Fail to open an envelope with an invalid hmac algorithm
+	secure.EncryptionAlgorithm = envelope.Cipher.EncryptionAlgorithm()
+	secure.HmacAlgorithm = "invalid"
+	_, err = handler.Open(secure, privateKey)
+	require.Error(t, err)
+
+	// Fail to open an envelope with an unsupported key type
+	secure.EncryptionAlgorithm = envelope.Cipher.EncryptionAlgorithm()
+	secure.HmacAlgorithm = envelope.Cipher.SignatureAlgorithm()
+	_, err = handler.Open(secure, nil)
+	require.Error(t, err)
+	_, err = handler.Open(secure, publicKey)
+	require.Error(t, err)
+
+	// Fail to open the envelope using the wrong key
+	wrongKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	_, err = handler.Open(secure, wrongKey)
+	require.Error(t, err)
+
+	// Successfully opening an envelope
+	opened, err := handler.Open(secure, privateKey)
+	require.NoError(t, err)
+	require.NotNil(t, opened)
+	require.Equal(t, envelope.ID, opened.ID)
+	require.Equal(t, envelope.Cipher, opened.Cipher)
+	require.True(t, proto.Equal(envelope.Payload, opened.Payload), "unexpected payload in opened envelope")
+}

--- a/pkg/trisa/mtls/mtls_test.go
+++ b/pkg/trisa/mtls/mtls_test.go
@@ -1,0 +1,77 @@
+package mtls_test
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trisacrypto/trisa/pkg/trisa/mtls"
+	"github.com/trisacrypto/trisa/pkg/trust"
+	"github.com/trisacrypto/trisa/pkg/trust/mock"
+	"google.golang.org/grpc"
+	"software.sslmate.com/src/go-pkcs12"
+)
+
+// Test that Config returns a valid TLS config.
+func TestConfig(t *testing.T) {
+	// Create private provider using the mock certificate chain
+	pfxData, err := mock.Chain()
+	require.NoError(t, err)
+	private, err := trust.Decrypt(pfxData, pkcs12.DefaultPassword)
+	require.NoError(t, err)
+
+	// Public provider should return an error
+	public := private.Public()
+	_, err = mtls.Config(public, trust.NewPool())
+	require.Error(t, err)
+
+	// Valid config
+	cfg, err := mtls.Config(private, trust.NewPool())
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.Len(t, cfg.Certificates, 1)
+	require.Equal(t, uint16(tls.VersionTLS12), cfg.MinVersion)
+	require.NotEmpty(t, cfg.CurvePreferences)
+	require.True(t, cfg.PreferServerCipherSuites)
+	require.NotEmpty(t, cfg.CipherSuites)
+	require.Equal(t, tls.RequireAndVerifyClientCert, cfg.ClientAuth)
+	require.NotNil(t, cfg.ClientCAs)
+}
+
+// Test that ServerCreds returns a grpc.ServerOption for mtls.
+func TestServerCreds(t *testing.T) {
+	// Create private provider using the mock certificate chain
+	pfxData, err := mock.Chain()
+	require.NoError(t, err)
+	private, err := trust.Decrypt(pfxData, pkcs12.DefaultPassword)
+	require.NoError(t, err)
+
+	// Public provider should return an error
+	public := private.Public()
+	_, err = mtls.ServerCreds(public, trust.NewPool())
+	require.Error(t, err)
+
+	// Succesfully retuning a grpc.ServerOption
+	opt, err := mtls.ServerCreds(private, trust.NewPool())
+	require.NoError(t, err)
+	require.Implements(t, (*grpc.ServerOption)(nil), opt)
+}
+
+// Test that ClientCreds returns a grpc.DialOption for mtls.
+func TestClientCreds(t *testing.T) {
+	// Create private provider using the mock certificate chain
+	pfxData, err := mock.Chain()
+	require.NoError(t, err)
+	private, err := trust.Decrypt(pfxData, pkcs12.DefaultPassword)
+	require.NoError(t, err)
+
+	// Public provider should return an error
+	public := private.Public()
+	_, err = mtls.ClientCreds("https://localhost:12345", public, trust.NewPool())
+	require.Error(t, err)
+
+	// Successfully returning a grpc.DialOption
+	opt, err := mtls.ClientCreds("https://localhost:12345", private, trust.NewPool())
+	require.NoError(t, err)
+	require.Implements(t, (*grpc.DialOption)(nil), opt)
+}

--- a/pkg/trust/mock/mock.go
+++ b/pkg/trust/mock/mock.go
@@ -1,0 +1,146 @@
+package mock
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"sync"
+	"time"
+
+	"github.com/trisacrypto/trisa/pkg/trust"
+	"software.sslmate.com/src/go-pkcs12"
+)
+
+// TestCA variables
+var (
+	initCAonce     sync.Once
+	rootCA         tls.Certificate
+	intermediateCA tls.Certificate
+	icaPrivKey     *rsa.PrivateKey
+)
+
+// Create a chain with a leaf node, an intermediate, and root ca + private key.
+func Chain() (data []byte, err error) {
+	initCAonce.Do(initCA)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(44),
+		Subject: pkix.Name{
+			CommonName:   "Test",
+			Organization: []string{"Test Net"},
+			Country:      []string{"XX"},
+		},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(0, 0, 7),
+		SubjectKeyId: []byte{1, 2, 3, 4, 5, 6},
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+
+	priv, _ := rsa.GenerateKey(rand.Reader, 4096)
+	pub := &priv.PublicKey
+
+	// Sign the certificate
+	var ca *x509.Certificate
+	if ca, err = x509.ParseCertificate(intermediateCA.Certificate[0]); err != nil {
+		return nil, err
+	}
+
+	var signed []byte
+	if signed, err = x509.CreateCertificate(rand.Reader, tmpl, ca, pub, icaPrivKey); err != nil {
+		return nil, err
+	}
+
+	var cert *x509.Certificate
+	if cert, err = x509.ParseCertificate(signed); err != nil {
+		return nil, err
+	}
+
+	var rca *x509.Certificate
+	if rca, err = x509.ParseCertificate(rootCA.Certificate[0]); err != nil {
+		return nil, err
+	}
+
+	return pkcs12.Encode(rand.Reader, priv, cert, []*x509.Certificate{ca, rca}, pkcs12.DefaultPassword)
+}
+
+func initCA() {
+	// Root CA
+	rootCAtmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(42),
+		Subject: pkix.Name{
+			CommonName:   "Test Root CA",
+			Organization: []string{"Test Root"},
+			Country:      []string{"XX"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	caPrivKey, _ := rsa.GenerateKey(rand.Reader, 4096)
+	data, err := x509.CreateCertificate(rand.Reader, rootCAtmpl, rootCAtmpl, &caPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		panic(err)
+	}
+
+	if rootCA, err = parseCertificate(data, caPrivKey); err != nil {
+		panic(err)
+	}
+
+	// Intermediate CA
+	interCAtmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(43),
+		Subject: pkix.Name{
+			CommonName:   "Test Intermediate CA",
+			Organization: []string{"Test Intermediate"},
+			Country:      []string{"XX"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+
+	ca, err := x509.ParseCertificate(rootCA.Certificate[0])
+	if err != nil {
+		panic(err)
+	}
+
+	icaPrivKey, _ = rsa.GenerateKey(rand.Reader, 4096)
+	if data, err = x509.CreateCertificate(rand.Reader, interCAtmpl, ca, &icaPrivKey.PublicKey, caPrivKey); err != nil {
+		panic(err)
+	}
+
+	if intermediateCA, err = parseCertificate(data, icaPrivKey); err != nil {
+		panic(err)
+	}
+
+}
+
+func parseCertificate(data []byte, priv *rsa.PrivateKey) (tls.Certificate, error) {
+	crt, err := x509.ParseCertificate(data)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	certPEMBlock, err := trust.PEMEncodeCertificate(crt)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	keyPEMBlock, err := trust.PEMEncodePrivateKey(priv)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	return tls.X509KeyPair(certPEMBlock, keyPEMBlock)
+}

--- a/pkg/trust/trust_test.go
+++ b/pkg/trust/trust_test.go
@@ -1,23 +1,16 @@
 package trust_test
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/tls"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"math/big"
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/trisacrypto/trisa/pkg/trust"
+	"github.com/trisacrypto/trisa/pkg/trust/mock"
 	"software.sslmate.com/src/go-pkcs12"
 )
 
 func TestPrivateProvider(t *testing.T) {
-	pfxData, err := chain()
+	pfxData, err := mock.Chain()
 	require.NoError(t, err)
 
 	p, err := trust.Decrypt(pfxData, pkcs12.DefaultPassword)
@@ -58,7 +51,7 @@ func TestPrivateProvider(t *testing.T) {
 }
 
 func TestPublicProvider(t *testing.T) {
-	pfxData, err := chain()
+	pfxData, err := mock.Chain()
 	require.NoError(t, err)
 
 	priv, err := trust.Decrypt(pfxData, pkcs12.DefaultPassword)
@@ -97,135 +90,4 @@ func TestPublicProvider(t *testing.T) {
 	require.NoError(t, o.Decode(pfxData))
 	require.Equal(t, p, o)
 	require.False(t, o.IsPrivate())
-}
-
-// TestCA variables
-var (
-	initCAonce     sync.Once
-	rootCA         tls.Certificate
-	intermediateCA tls.Certificate
-	icaPrivKey     *rsa.PrivateKey
-)
-
-// Create a chain with a leaf node, an intermediate, and root ca + private key.
-func chain() (data []byte, err error) {
-	initCAonce.Do(initCA)
-
-	tmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(44),
-		Subject: pkix.Name{
-			CommonName:   "Test",
-			Organization: []string{"Test Net"},
-			Country:      []string{"XX"},
-		},
-		NotBefore:    time.Now(),
-		NotAfter:     time.Now().AddDate(0, 0, 7),
-		SubjectKeyId: []byte{1, 2, 3, 4, 5, 6},
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
-		KeyUsage:     x509.KeyUsageDigitalSignature,
-	}
-
-	priv, _ := rsa.GenerateKey(rand.Reader, 4096)
-	pub := &priv.PublicKey
-
-	// Sign the certificate
-	var ca *x509.Certificate
-	if ca, err = x509.ParseCertificate(intermediateCA.Certificate[0]); err != nil {
-		return nil, err
-	}
-
-	var signed []byte
-	if signed, err = x509.CreateCertificate(rand.Reader, tmpl, ca, pub, icaPrivKey); err != nil {
-		return nil, err
-	}
-
-	var cert *x509.Certificate
-	if cert, err = x509.ParseCertificate(signed); err != nil {
-		return nil, err
-	}
-
-	var rca *x509.Certificate
-	if rca, err = x509.ParseCertificate(rootCA.Certificate[0]); err != nil {
-		return nil, err
-	}
-
-	return pkcs12.Encode(rand.Reader, priv, cert, []*x509.Certificate{ca, rca}, pkcs12.DefaultPassword)
-}
-
-func initCA() {
-	// Root CA
-	rootCAtmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(42),
-		Subject: pkix.Name{
-			CommonName:   "Test Root CA",
-			Organization: []string{"Test Root"},
-			Country:      []string{"XX"},
-		},
-		NotBefore:             time.Now(),
-		NotAfter:              time.Now().AddDate(10, 0, 0),
-		IsCA:                  true,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
-		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-		BasicConstraintsValid: true,
-	}
-
-	caPrivKey, _ := rsa.GenerateKey(rand.Reader, 4096)
-	data, err := x509.CreateCertificate(rand.Reader, rootCAtmpl, rootCAtmpl, &caPrivKey.PublicKey, caPrivKey)
-	if err != nil {
-		panic(err)
-	}
-
-	if rootCA, err = parseCertificate(data, caPrivKey); err != nil {
-		panic(err)
-	}
-
-	// Intermediate CA
-	interCAtmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(43),
-		Subject: pkix.Name{
-			CommonName:   "Test Intermediate CA",
-			Organization: []string{"Test Intermediate"},
-			Country:      []string{"XX"},
-		},
-		NotBefore:             time.Now(),
-		NotAfter:              time.Now().AddDate(10, 0, 0),
-		IsCA:                  true,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
-		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
-		BasicConstraintsValid: true,
-	}
-
-	ca, err := x509.ParseCertificate(rootCA.Certificate[0])
-	if err != nil {
-		panic(err)
-	}
-
-	icaPrivKey, _ = rsa.GenerateKey(rand.Reader, 4096)
-	if data, err = x509.CreateCertificate(rand.Reader, interCAtmpl, ca, &icaPrivKey.PublicKey, caPrivKey); err != nil {
-		panic(err)
-	}
-
-	if intermediateCA, err = parseCertificate(data, icaPrivKey); err != nil {
-		panic(err)
-	}
-
-}
-
-func parseCertificate(data []byte, priv *rsa.PrivateKey) (tls.Certificate, error) {
-	crt, err := x509.ParseCertificate(data)
-	if err != nil {
-		return tls.Certificate{}, err
-	}
-
-	certPEMBlock, err := trust.PEMEncodeCertificate(crt)
-	if err != nil {
-		return tls.Certificate{}, err
-	}
-
-	keyPEMBlock, err := trust.PEMEncodePrivateKey(priv)
-	if err != nil {
-		return tls.Certificate{}, err
-	}
-
-	return tls.X509KeyPair(certPEMBlock, keyPEMBlock)
 }


### PR DESCRIPTION
This adds tests for the secure envelope handling code in `pkg/trisa/handler/handler.go` and the mtls config code in `pkg/trisa/mtls/mtls.go`