### PR TITLE
Correct LegalPerson validation

### DIFF
--- a/pkg/ivms101/ivms101.go
+++ b/pkg/ivms101/ivms101.go
@@ -117,12 +117,21 @@ func (p *LegalPerson) Validate() (err error) {
 		}
 
 		// Constraint: CompleteNationalIdentifierLegalPerson
+		// C9 means that Country of Issue must **only** be used for natural persons
+		if p.NationalIdentification.CountryOfIssue != "" {
+			return ErrCompleteNationalIdentifierLegalPerson
+		}
 		if p.NationalIdentification.NationalIdentifierType != NationalIdentifierLEIX {
-			if p.NationalIdentification.CountryOfIssue != "" || p.NationalIdentification.RegistrationAuthority == "" {
+			// if the ID is not LEIX, Registration Authority is mandatory
+			if p.NationalIdentification.RegistrationAuthority == "" {
+				return ErrCompleteNationalIdentifierLegalPerson
+			}
+		} else {
+			// if the ID is an LEIX, Registration Authority must be empty
+			if p.NationalIdentification.RegistrationAuthority != "" {
 				return ErrCompleteNationalIdentifierLegalPerson
 			}
 		}
-
 	}
 
 	// Constraint: Optional ISO-3166-1 alpha-2 codes or XX

--- a/pkg/ivms101/ivms101_test.go
+++ b/pkg/ivms101/ivms101_test.go
@@ -16,7 +16,25 @@ func TestLegalPerson(t *testing.T) {
 	// Should be able to load a valid legal person from JSON data
 	var person *ivms101.LegalPerson
 	require.NoError(t, json.Unmarshal(data, &person))
+
+	// Legal person can't have a Country of Issue
 	require.NoError(t, person.Validate())
+	person.NationalIdentification.CountryOfIssue = "GB"
+	require.Error(t, person.Validate())
+
+	// If the National Identifier is an LEI, Registration Authority must be empty
+	person.NationalIdentification.CountryOfIssue = ""
+	person.NationalIdentification.NationalIdentifierType = 9
+	person.NationalIdentification.RegistrationAuthority = ""
+	require.NoError(t, person.Validate())
+	person.NationalIdentification.RegistrationAuthority = "Chuck Norris"
+	require.Error(t, person.Validate())
+
+	// If the National Identifier is not an LEI, Registration Authority is mandatory
+	person.NationalIdentification.NationalIdentifierType = 3
+	require.NoError(t, person.Validate())
+	person.NationalIdentification.RegistrationAuthority = ""
+	require.Error(t, person.Validate())
 
 	// Correct name can be validated
 	require.NoError(t, person.Name.Validate())

--- a/pkg/ivms101/testdata/legalperson.json
+++ b/pkg/ivms101/testdata/legalperson.json
@@ -24,9 +24,7 @@
     "customer_number": "",
     "national_identification": {
         "national_identifier": "213800AQUAUP6I215N33",
-        "national_identifier_type": 9,
-        "country_of_issue": "GB",
-        "registration_authority": "RA000589"
+        "national_identifier_type": 9
     },
     "country_of_registration": "GB"
 }


### PR DESCRIPTION
This PR addresses sc-2407 by slightly adjusting the IVMS101 validation logic for the `LegalPerson` `NationalIdentification` fields based on the following guidance from XREX:

- Country of Issue must only be used for natural persons and
- If the National Identifier is an LEI, Registration Authority must be empty and
- If the National Identifier is not an LEI, Registration Authority is mandatory.