### PR TITLE
Update integration page references

### DIFF
--- a/docs/content/testnet/rvasps.de.md
+++ b/docs/content/testnet/rvasps.de.md
@@ -46,7 +46,7 @@ Wenn Sie ein Traveler-Kunde sind, haben die fettgedruckten Adressen oben einige 
 
 ### Präliminarien
 
-In dieser Dokumentation wird davon ausgegangen, dass Sie einen Dienst haben, der den neuesten `TRISANetwork`-Dienst ausführt, und dass er im TRISA TestNet registriert ist und TestNet-Zertifikate korrekt installiert hat. Weitere Informationen finden Sie in der [TRISA-Integrationsübersicht]({{< ref "integration/_index.md" >}}). **WARNUNG**: Die rVASPs nehmen nicht am TRISA-Produktionsnetz teil, sie antworten nur auf verifizierte TRISA TestNet mTLS-Verbindungen.
+In dieser Dokumentation wird davon ausgegangen, dass Sie einen Dienst haben, der den neuesten `TRISANetwork`-Dienst ausführt, und dass er im TRISA TestNet registriert ist und TestNet-Zertifikate korrekt installiert hat. Weitere Informationen finden Sie in der [TRISA-Integrationsübersicht]({{< ref "getting-started/_index.md" >}}). **WARNUNG**: Die rVASPs nehmen nicht am TRISA-Produktionsnetz teil, sie antworten nur auf verifizierte TRISA TestNet mTLS-Verbindungen.
 
 Um mit der rVASP-API zu interagieren, können Sie entweder:
 

--- a/docs/content/testnet/rvasps.en.md
+++ b/docs/content/testnet/rvasps.en.md
@@ -48,7 +48,7 @@ In order to support multiple behaviors at once, such as synchronous and asynchro
 
 ### Preliminaries
 
-This documentation assumes that you have a service that is running the latest `TRISANetwork` service and that it has been registered in the TRISA TestNet and correctly has TestNet certificates installed. See [ TRISA Integration Overview]({{< ref "integration/_index.md" >}}) for more information. **WARNING**: the rVASPs do not participate in the TRISA production network, they will only respond to verified TRISA TestNet mTLS connections.
+This documentation assumes that you have a service that is running the latest `TRISANetwork` service and that it has been registered in the TRISA TestNet and correctly has TestNet certificates installed. See [ TRISA Integration Overview]({{< ref "getting-started/_index.md" >}}) for more information. **WARNING**: the rVASPs do not participate in the TRISA production network, they will only respond to verified TRISA TestNet mTLS connections.
 
 To interact with the rVASP API, you may either:
 
@@ -115,7 +115,7 @@ It is then up to your TRISA node to determine how to handle the payload. Your op
 
 The rVASP handles each type of response appropriately. If a reject message is returned, the rVASP fails the transaction; if accept it "executes" the transaction.
 
-The pending message initiates an asynchronous transaction. The transaction is placed into an "await" state until the rVASP receives a follow-up reject or accept response with the same envelope id. 
+The pending message initiates an asynchronous transaction. The transaction is placed into an "await" state until the rVASP receives a follow-up reject or accept response with the same envelope id.
 
 #### Originator Policies
 
@@ -180,7 +180,7 @@ autonumber
     activate Bob
     Bob-->>Alice: Pending (5-10 min)
     activate Alice
-    Bob->>Alice: Transfer() Full Identity Info + received_at 
+    Bob->>Alice: Transfer() Full Identity Info + received_at
     deactivate Bob
     Alice->>Bob: Echo Payload
     deactivate Alice
@@ -188,7 +188,7 @@ autonumber
     activate Bob
     Bob-->>Alice: Pending (5-10 min)
     activate Alice
-    Bob->>Alice: Transfer() Full Identity Info + Full Transaction + received_at 
+    Bob->>Alice: Transfer() Full Identity Info + Full Transaction + received_at
     deactivate Bob
     Alice->>Bob: Echo Payload
     deactivate Alice

--- a/docs/content/testnet/rvasps.fr.md
+++ b/docs/content/testnet/rvasps.fr.md
@@ -46,7 +46,7 @@ Si vous êtes un client de Traveler, les adresses en gras ci-dessus sont associ�
 
 ### Préliminaires
 
-Cette documentation suppose que vous avez un service qui exécute la dernière version du service `TRISANetwork` et qu'il a été enregistré dans le TestNet TRISA et que les certificats TestNet sont correctement installés. Voir [Vue d'ensemble de l'intégration de TRISA]({{< ref "integration/_index.md" >}}) pour plus d’informations. **AVERTISSEMENT**: les rVASP ne participent pas au réseau de production TRISA, ils ne répondent qu'aux connexions mTLS vérifiées de TRISA TestNet.
+Cette documentation suppose que vous avez un service qui exécute la dernière version du service `TRISANetwork` et qu'il a été enregistré dans le TestNet TRISA et que les certificats TestNet sont correctement installés. Voir [Vue d'ensemble de l'intégration de TRISA]({{< ref "getting-started/_index.md" >}}) pour plus d’informations. **AVERTISSEMENT**: les rVASP ne participent pas au réseau de production TRISA, ils ne répondent qu'aux connexions mTLS vérifiées de TRISA TestNet.
 
 Pour interagir avec l'API rVASP, vous pouvez soit :
 

--- a/docs/content/testnet/rvasps.ja.md
+++ b/docs/content/testnet/rvasps.ja.md
@@ -46,7 +46,7 @@ rVASPには、偽のウォレットアドレスを持つ偽の顧客のデータ
 
 ### 予選
 
-このドキュメントは、最新の「TRISA ネットワーク」サービスを実行しているサービスがあり、そのサービスがTRISA TestNetに登録されており、TestNet証明書が正しくインストールされていることを前提としています。 [TRISA統合の概要を参照してください]({{< ref "integration/_index.md" >}}) 詳細については。 **警告**: rVASPはTRISAネットワークに参加せず、検証済みのTRISA  TestNet mTLS接続にのみ応答します。
+このドキュメントは、最新の「TRISA ネットワーク」サービスを実行しているサービスがあり、そのサービスがTRISA TestNetに登録されており、TestNet証明書が正しくインストールされていることを前提としています。 [TRISA統合の概要を参照してください]({{< ref "getting-started/_index.md" >}}) 詳細については。 **警告**: rVASPはTRISAネットワークに参加せず、検証済みのTRISA  TestNet mTLS接続にのみ応答します。
 
 rVASP APIと対話するには、次のいずれかを実行できます。
 

--- a/docs/content/testnet/rvasps.zh.md
+++ b/docs/content/testnet/rvasps.zh.md
@@ -46,7 +46,7 @@ rVASP有一个内置的数据库，里面存储着带有假钱包地址的假客
 
 ### 条件
 
-本文档假设您有一个正在运行最新`TRISANetwork`的服务，并且它已经在TRISA TestNet中注册，并且正确地安装了TestNet证书。参见[TRISA 集成概况]({{< ref "integration/_index.md" >}})了解更多信息。**警告**: rVASP不参与TRISA工作网络，他们将只响应已验证的TRISA TestNet mTLS连接。
+本文档假设您有一个正在运行最新`TRISANetwork`的服务，并且它已经在TRISA TestNet中注册，并且正确地安装了TestNet证书。参见[TRISA 集成概况]({{< ref "getting-started/_index.md" >}})了解更多信息。**警告**: rVASP不参与TRISA工作网络，他们将只响应已验证的TRISA TestNet mTLS连接。
 
 要与rVASP API交互，您可以:
 


### PR DESCRIPTION
The integration page has been renamed `getting-started`; this PR updates the relative references to this section of the docs to repair broken links.