### PR TITLE
Updates to "getting started" section

### DIFF
--- a/docs/content/gds/_index.en.md
+++ b/docs/content/gds/_index.en.md
@@ -10,12 +10,13 @@ The TRISA organization hosts the TRISA Global Directory Service (GDS) on behalf 
 
 - By issuing mTLS certificates to verify exchanges
 - By providing discovery services for finding TRISA endpoints
-- By providing certificate and KYCV (Know Your Counterparty VASP) information for verification  
+- By providing certificate and KYCV (Know Your Counterparty VASP) information for verification
+
 It is important to note that TRISA is a peer-to-peer network with no centralized authority for collecting or exchanging Travel Rule data.
 
 GDS serves as a Certificate Authority for TRISA exchanges. After VASPs submit required information and are verified, GDS issues them Identity Certificates which VASPs can use to establish mTLS connections with counterparties, thereby securing communications that contain private Originator and Beneficiary data. These certificates are issued after extended validation and prove that the VASP is a trusted member of the TRISA network. In this way, GDS does not control the exchange; rather it helps to confirm the identities of parties involved in Travel Rule information exchanges.
 
-GDS also serves as a decentralized store of member information, including member node (aka endpoint) addresses, TRIXO form details, and public keys. TRISA members can access the directory listing of other verified members, search, and lookup VASP counterparties. In this way, GDS helps members to make informed compliance decisions before sending or receiving large sums of virtual assets. 
+GDS also serves as a decentralized store of member information, including member node (aka endpoint) addresses, TRIXO form details, and public keys. TRISA members can access the directory listing of other verified members, search, and lookup VASP counterparties. In this way, GDS helps members to make informed compliance decisions before sending or receiving large sums of virtual assets.
 
 GDS is replicated across multiple continents. The servers hosting GDS are in three regions: US, EU, and Singapore. The servers are decentralized and geo-replicated to ensure that the GDS is consistent, available, and fault-tolerant. TRISA plans to expand to more regions in the future.
 

--- a/docs/content/getting-started/_index.en.md
+++ b/docs/content/getting-started/_index.en.md
@@ -6,71 +6,73 @@ description: "Describes how to integrate the TRISA protocol in the TestNet"
 weight: 20
 ---
 
-## TRISA Integration Overview
+
+## Getting Started with TRISA
+
+There are three key steps to getting started integrating TRISA into your organization's Travel Rule solution:
 
 1. Register with a TRISA Directory Service
 2. Implement the TRISA Network protocol
 3. Implement the TRISA Health protocol
 
+This page will walk through each of these three steps, providing links to other resources as necessary.
+
 ## VASP Directory Service Registration
+
+Before you can integrate the TRISA protocol into your VASP software, you must [register](https://vaspdirectory.net/certificate/registration) with the TRISA Global Directory Service (GDS).
 
 ### Registration Overview
 
-Before you can integrate the TRISA protocol into your VASP software, you must register with a TRISA Directory Service (DS).  The TRISA DS provides public key and TRISA remote peer connection information for registered VASPs.
+The TRISA Global Directory Service (GDS) provides public key and TRISA remote peer connection information for registered VASPs. For more detailed information about the directory, see the documentation on the [GDS]({{< ref "/gds" >}}).
 
-Once you have registered with the TRISA DS, you will receive a KYV certificate.  The public key in the KYV certificate will be made available to other VASPs via the TRISA DS.
+Once you have registered with the GDS and been verified, you will receive Identity Certificates. The public key in these certificate will be made available to other VASPs via the GDS.
 
-When registering with the DS, you will need to provide the `address:port` endpoint where your VASP implements the TRISA Network service. This address will be registered with the DS and utilized by other VASPs when your VASP is identified as the beneficiary VASP.
+When registering with the GDS, you will need to provide the `address:port` endpoint where your VASP implements the TRISA Network service. This address will be registered with the GDS and utilized by other VASPs when your VASP is identified as the beneficiary VASP.
 
-For integration purposes, a hosted TestNet TRISA DS instance is available for testing.  The registration process is streamlined in the TestNet to facilitate quick integration.  It is recommended to start the production DS registration while integrating with the TestNet.
+For integration purposes, when you [register](https://vaspdirectory.net/certificate/registration) with the GDS, you can opt for either MainNet or TestNet Certificates, or both. The TestNet instance is designed for testing, and the registration process is streamlined in the TestNet to facilitate quick integration. The MainNet is design for production Travel Rule implementations. It is recommended to register for both MainNet and TestNet, specifying different endpoints for to reduce confusion for your VASP counterparties.
 
+For more complete details, visit the documentation on [registration]({{< ref "/joining-trisa/registration" >}}).
 
 ### Directory Service Registration
 
-To start registration with the TRISA DS, visit website at [https://vaspdirectory.net/](https://vaspdirectory.net/)
+To start your registration, visit [https://vaspdirectory.net/](https://vaspdirectory.net/certificate/registration). Note that you can use this website to enter your registration details on a field-by-field basis, or to upload a JSON document containing your registration details. The final step of registration will be a [pkcs12 password]({{< ref "/joining-trisa/pkcs12" >}}), which you must keep to decrypt the Identity Certificates that will be sent via email.
 
-You can select the "Register" tab to begin registration. Note that you can use this website to enter your registration details on a field-by-field basis, or to upload a JSON document containing your registration details.
+This registration will result in an email being sent to all the technical contacts specified through the webform or in the JSON file. The emails will guide you through the remainder of the registration process. Once you’ve completed the registration steps, TRISA administrators will receive your registration for review.
 
-This registration will result in an email being sent to all the technical contacts specified in the JSON file.  The emails will guide you through the remainder of the registration process.  Once you’ve completed the registration steps, TRISA TestNet administrators will receive your registration for review.
-
-Once TestNet administrators have reviewed and approved the registration, you will receive a KYV certificate via email and your VASP will be publicly visible in the TestNet DS.
+Once the administrators have reviewed and approved the registration, you will receive [pkcs12 password]({{< ref "/joining-trisa/pkcs12" >}})-protected, compressed Identity Certificate via email and your VASP will be publicly visible in the GDS.
 
 
 ## Implementing the TRISA P2P Protocol
-
 
 ### Prerequisites
 
 To begin setup, you’ll need the following:
 
-
-
-*   KYV certificate (from TRISA DS registration)
+*   Identity Certificates (from TRISA GDS registration)
 *   The public key used for the CSR to obtain your certificate
 *   The associated private key
 *   The host name of the TRISA directory service
-*   Ability to bind to the address:port that is associated with your VASP in the TRISA directory service.
-
+*   Ability to bind to the `address:port` that is associated with your VASP in the TRISA directory service.
 
 ### Integration Overview
 
+Integrating VASPs must run their own implementation of the protocol. Integrators are expected to integrate incoming transfer requests and key exchanges and may optionally also integrate outgoing transfer requests and key exchanges.
+
 Integrating the TRISA protocol involves both a client component and server component.
 
-The client component will interface with a TRISA Directory Service (DS) instance to lookup other VASPs that integrate the TRISA messaging protocol.  The client component is utilized for outgoing transactions from your VASP to verify the receiving VASP is TRISA compliant.
+The client component will interface with the TRISA Global Directory Service (GDS) instance to lookup other VASPs that integrate the TRISA messaging protocol. The client component is utilized for outgoing transactions from your VASP to verify the receiving VASP is TRISA compliant.
 
-The server component receives requests from other VASPs that integrate the TRISA protocol and provides responses to their requests.  The server component provides callbacks that must be implemented so that your VASP can return information satisfying the TRISA Network protocol.
+The server component receives requests from other VASPs that integrate the TRISA protocol and provides responses to their requests. The server component provides callbacks that must be implemented so that your VASP can return information satisfying the TRISA Network protocol.
 
 Currently, a reference implementation of the TRISA Network protocol is available in Go.
 
 [https://github.com/trisacrypto/testnet/blob/main/pkg/rvasp/trisa.go](https://github.com/trisacrypto/testnet/blob/main/pkg/rvasp/trisa.go)
 
-Integrating VASPs must run their own implementation of the protocol.  If a language beside Go is required, client libraries may be generated from the protocol buffers that define the TRISA Network protocol.
-
-Integrators are expected to integrate incoming transfer requests and key exchanges and may optionally also integrate outgoing transfer requests and key exchanges.
+If a language beside Go is required, client libraries may be generated from the [protocol buffers](https://github.com/trisacrypto/trisa/tree/main/proto) that define the TRISA Network protocol.
 
 ### Integration Notes
 
-The TRISA Network protocol defines how data is transferred between participating VASPs.  The recommended format for data transferred for identifying information is the IVMS101 data format.  It is the responsibility of the implementing VASP to ensure the identifying data sent/received satisfies the FATF Travel Rule.
+The TRISA Network protocol defines how data is transferred between participating VASPs. The recommended format for data transferred for identifying information is the IVMS101 data format. It is the responsibility of the implementing VASP to ensure the identifying data sent/received satisfies the FATF Travel Rule.
 
-The result of a successful TRISA transaction results in a key and encrypted data that satisfies the FATF Travel Rule.  TRISA does not define how this data should be stored once obtained.  It is the responsibility of the implementing VASP to handle the secure storage of the resulting data for the transaction.
+The result of a successful TRISA transaction results in a key and encrypted data that satisfies the FATF Travel Rule. TRISA does not define how this data should be stored once obtained. It is the responsibility of the implementing VASP to handle the secure storage of the resulting data for the transaction.
 

--- a/docs/content/joining-trisa/_index.en.md
+++ b/docs/content/joining-trisa/_index.en.md
@@ -6,9 +6,11 @@ description: "Describes how to join TRISA"
 weight: 21
 ---
 
-To join the TRISA or TestNet networks, you must register with the TRISA Global Directory Service (GDS) or one of the jurisdiction-specific directory services. Registering with the directory service engages two workflows:
+To join the TRISA network, you must register with the [TRISA Global Directory Service (GDS)]({{< ref "/gds" >}}).
+
+Registering with the directory service engages two workflows:
 
 1. A KYV review process to ensure the network maintains trusted membership
 2. Certificate issuance for mTLS authentication in the network
 
-Coming soon: more details on the registration form, email verification, and the review process.
+Next, learn more about [registration]({{< ref "/joining-trisa/registration" >}}).


### PR DESCRIPTION
This PR refreshes the "Getting Started" (formerly "Integration Overview") portion of the docs, providing a bit more clarification, correcting outdated information, and including relative links to make the docs easier to navigate.