### PR TITLE
added pkg/trisa doc.go [SC-4373]

### DIFF
--- a/docs/content/data-payloads/_index.en.md
+++ b/docs/content/data-payloads/_index.en.md
@@ -40,26 +40,31 @@ To ensure compatibility with fellow TRISA members and convenient message parsing
 
 ### A `Transaction` Message
 
-A `Transaction` is a generic message for TRISA transaction payloads. The goal of this payload is to provide enough information to link Travel Rule compliance information in the `identity` payload with a transaction on the blockchain or network. 
+A `Transaction` is a generic message for TRISA transaction payloads. The goal of this payload is to provide enough information to link Travel Rule compliance information in the `identity` payload with a transaction on the blockchain or network.
 
 ```proto
 message Transaction {
-    string txid = 1;           // Transaction hash, to notify beneficiary VASP of the transaction sent by originating VASP
+    string txid = 1;           // Transaction ID or hash unique to chain
+                               // Used to notify beneficiary VASP of the transaction
+                               // sent by the originating VASP.
+
     string originator = 2;     // Crypto address of originator
     string beneficiary = 3;    // Crypto address of beneficiary
     double amount = 4;         // Amount of transaction
-    string network = 5;        // Network ticker (E.g.: ETH, BTC, etc) 
+    string network = 5;        // Chain of transaction/network ticker (e.g.: ETH, BTC)
     string timestamp = 6;      // Transaction timestamp (RFC 3339)
     string extra_json = 7;     // Extra data (JSON-formatted)
 
-    string asset_type = 8;     // Token ticker, for identifying the token on chain. 
-                               // For native token, set this field the same as network ticker (E.g.: ETH, BTC, USDT, etc)
+    string asset_type = 8;     // Token ticker, for identifying the token on chain.
+                               // For native tokens, set to the same as network ticker
+                               // (e.g.: ETH, BTC, USDT, etc)
 
     string tag = 9;            // Optional address memo/destination-tag
 }
 ```
 
-Example: 
+Below are some examples of how the `Transaction` message might be used in the context of different types of transactions and chains.
+
 1. Blockchain without smart contract (e.g.: BTC)
     ```json
     {
@@ -75,7 +80,7 @@ Example:
    }
    ```
 
-2. Blockchain supports smart contract (e.g.: ETH)
+2. Blockchain supporting a smart contract (e.g.: ETH)
     - Native token
         ```json
         {
@@ -90,10 +95,11 @@ Example:
           "tag": ""
         }
         ```
+
     - Custom token (e.g.: ERC20)
         ```json
         {
-          
+
           "txid": "0x6286b5688bcc789c2d681c01beb3e49ac870de15461cb5a90d14b8a161e84236",
           "originator": "0xea0b5f97c3843175ee67ddb237e294a9144c0a68",
           "beneficiary": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
@@ -105,7 +111,8 @@ Example:
           "tag": ""
         }
         ```
-3. Blockchain supports destination tag (e.g.: XRP)
+
+3. Blockchain supporting destination tags (e.g.: XRP)
     ```json
     {
       "txid": "BFD895E1D93FB6E25A3BE38A2E62B6D88753F502B4C6E55F297981538538A2F2",
@@ -117,7 +124,7 @@ Example:
       "extra_json": "{\"value_when_transacted\": \"USD $32.53\"}",
       "asset_type": "XRP",
       "tag": "311041419"
-   } 
+   }
 
     ```
 

--- a/pkg/trisa/doc.go
+++ b/pkg/trisa/doc.go
@@ -4,25 +4,16 @@ Use of this source code is governed by the MIT License that can be found in
 the LICENSE file.
 
 Package trisa hosts several subpackages, methods, and structs for a range of
-TRISA-related tasks. The packages include:
+TRISA-related tasks. The packages include the following:
 
-- api
-
-- crypto
-
-- envelope
-
-- data
-
-- gds
-
-- handler
-
-- keys
-
-- mtls
-
-- peers
+Package api implements the  TRISANetwork service that defines the peer-to-peer
+interactions between VASPs necessary to conduct compliance information
+exchanges. All TRISA members must implement all services described by the TRISA
+protocol to ensure that exchanges are conducted correctly and securely. The
+primary RPCs are Transfer and TransferStream, which allow VASPs to exchange
+compliance information before conducting a virtual asset transaction. The other
+RPCs facilitate Transfers, allowing address confirmations before a transfer
+and public key exchange so that transaction envelopes can be encrypted and signed.
 
 Package crypto describes interfaces for the various encryption and hmac
 algorithms that might be used to encrypt and sign transaction envelopes

--- a/pkg/trisa/doc.go
+++ b/pkg/trisa/doc.go
@@ -6,7 +6,9 @@ the LICENSE file.
 Package trisa hosts several subpackages, methods, and structs for a range of
 TRISA-related tasks. The packages include the following:
 
-Package api implements the  TRISANetwork service that defines the peer-to-peer
+`api`
+
+Package api implements the TRISANetwork service that defines the peer-to-peer
 interactions between VASPs necessary to conduct compliance information
 exchanges. All TRISA members must implement all services described by the TRISA
 protocol to ensure that exchanges are conducted correctly and securely. The
@@ -14,6 +16,8 @@ primary RPCs are Transfer and TransferStream, which allow VASPs to exchange
 compliance information before conducting a virtual asset transaction. The other
 RPCs facilitate Transfers, allowing address confirmations before a transfer
 and public key exchange so that transaction envelopes can be encrypted and signed.
+
+`crypto`
 
 Package crypto describes interfaces for the various encryption and hmac
 algorithms that might be used to encrypt and sign transaction envelopes
@@ -24,8 +28,10 @@ legal in different countries, these interfaces allow the use of different
 algorithms and methodologies in the protocol without specifying what must
 be used.
 
-Package envelope replaces the handler Package to provide utilities for
-encrypting and decrypting trisa. SecureEnvelopes as well as sealing and
+`envelope`
+
+Package envelope replaces the handler package to provide utilities for
+encrypting and decrypting trisa messages. SecureEnvelopes as well as sealing and
 unsealing them. SecureEnvelopes are the unit of transfer in a TRISA
 transaction and are used to securely exchange sensitive compliance
 information. Security is provided through two forms of cryptography:
@@ -33,11 +39,15 @@ symmetric cryptography to encrypt and sign the TRISA payload and
 asymmetric cryptography to seal the keys and secrets of the envelopes
 so that only the recipient can open it.
 
+`data`
+
 Package data contains the Generic Transaction message for TRISA
 transaction payloads. The payload aims to provide enough information
 to link Travel Rule Compliance information in the identity payload
 with a transaction on the blockchain or network. All fields are optional,
 this message serves as a convenience for parsing transaction payloads.
+
+`gds`
 
 Package gds contains the TRISADirectory API subpackage and TRISADirectory
 models subpackage. TheTRISADirectory API implements the TRISADirectory service
@@ -50,18 +60,26 @@ service. It maintains the version information to detect changes with respect
 to a specific registered directory and facilitates anti-entropy gossip
 protocols.
 
+`handler`
+
 Package handler provides the envelope struct that wraps a SecureEnvelope
 containing all of the information necessary to access the payload data.
 The envelope can be edited and resealed to simplify TRISA exchanges.
+
+`keys`
 
 Package keys provides interfaces and handlers for managing public/private key
 pairs that are used for sealing and unsealing secure envelopes. This package
 is not intended for use with symmetric keys that are used to encrypt payloads.
 
+`mtls`
+
 Package mtls provides methods that return the standard TLS configuration
 for the TRISA network, loading the certificate from the specified provider.
 Using the TLS configuration ensures that all TRISA peer-to-peer connections
 are handled and verified correctly.
+
+`peers`
 
 Package peers provides structs and methods to facilitate information exchanges
 to other members of the TRISA network and directory service lookups.

--- a/pkg/trisa/doc.go
+++ b/pkg/trisa/doc.go
@@ -1,0 +1,82 @@
+/*
+Copyright (c) 2022 by the TRISA contributors. All rights reserved.
+Use of this source code is governed by the MIT License that can be found in
+the LICENSE file.
+
+Package trisa hosts several subpackages, methods, and structs for a range of
+TRISA-related tasks. The packages include:
+
+- api
+
+- crypto
+
+- envelope
+
+- data
+
+- gds
+
+- handler
+
+- keys
+
+- mtls
+
+- peers
+
+Package crypto describes interfaces for the various encryption and hmac
+algorithms that might be used to encrypt and sign transaction envelopes
+being passed securely in the TRISA network. Subpackages implement
+specific algorithms such as aesgcm for symmetric encryption or rsa for
+asymmetric encryption. Note that not all encryption mechanisms are
+legal in different countries, these interfaces allow the use of different
+algorithms and methodologies in the protocol without specifying what must
+be used.
+
+Package envelope replaces the handler Package to provide utilities for
+encrypting and decrypting trisa. SecureEnvelopes as well as sealing and
+unsealing them. SecureEnvelopes are the unit of transfer in a TRISA
+transaction and are used to securely exchange sensitive compliance
+information. Security is provided through two forms of cryptography:
+symmetric cryptography to encrypt and sign the TRISA payload and
+asymmetric cryptography to seal the keys and secrets of the envelopes
+so that only the recipient can open it.
+
+Package data contains the Generic Transaction message for TRISA
+transaction payloads. The payload aims to provide enough information
+to link Travel Rule Compliance information in the identity payload
+with a transaction on the blockchain or network. All fields are optional,
+this message serves as a convenience for parsing transaction payloads.
+
+Package gds contains the TRISADirectory API subpackage and TRISADirectory
+models subpackage. TheTRISADirectory API implements the TRISADirectory service
+that specifies how TRISA clients should interact with a directory service to
+facilitate P2P transfers. And the TRISADirectory models subpackage contains
+the VASP struct definition that represents the top-level directory entry for
+certificate public key exchange. A VASP entry is also the primary point of
+replication between directories that implement the directory replication
+service. It maintains the version information to detect changes with respect
+to a specific registered directory and facilitates anti-entropy gossip
+protocols.
+
+Package handler provides the envelope struct that wraps a SecureEnvelope
+containing all of the information necessary to access the payload data.
+The envelope can be edited and resealed to simplify TRISA exchanges.
+
+Package keys provides interfaces and handlers for managing public/private key
+pairs that are used for sealing and unsealing secure envelopes. This package
+is not intended for use with symmetric keys that are used to encrypt payloads.
+
+Package mtls provides methods that return the standard TLS configuration
+for the TRISA network, loading the certificate from the specified provider.
+Using the TLS configuration ensures that all TRISA peer-to-peer connections
+are handled and verified correctly.
+
+Package peers provides structs and methods to facilitate information exchanges
+to other members of the TRISA network and directory service lookups.
+
+It is important to note that most of the subpackages in this repository are
+independent and they are implemented and tested separately from other
+subpackages.
+*/
+package trisa


### PR DESCRIPTION
[SC-4373](https://app.shortcut.com/rotational/story/4373/add-doc-go-to-pkg-trisa-package)

@rebeccabilbro I used `/*` `*/` tags since  `godoc`  was not rendering text with`//` 