### PR TITLE
IVMS101 Database Interface

### DIFF
--- a/pkg/ivms101/db.go
+++ b/pkg/ivms101/db.go
@@ -1,0 +1,109 @@
+package ivms101
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+)
+
+func (i *IdentityPayload) Scan(src interface{}) error {
+	p := IdentityPayload{}
+	if err := ScanJSON(src, &p); err != nil {
+		return err
+	}
+
+	*i = p
+	return nil
+}
+
+func (i *IdentityPayload) Value() (_ driver.Value, err error) {
+	return ValueJSON(i)
+}
+
+func (p *Person) Scan(src interface{}) error {
+	o := Person{}
+	if err := ScanJSON(src, &o); err != nil {
+		return err
+	}
+
+	*p = o
+	return nil
+}
+
+func (p *Person) Value() (_ driver.Value, err error) {
+	return ValueJSON(p)
+}
+
+func (p *NaturalPerson) Scan(src interface{}) error {
+	o := NaturalPerson{}
+	if err := ScanJSON(src, &o); err != nil {
+		return err
+	}
+
+	*p = o
+	return nil
+}
+
+func (p *NaturalPerson) Value() (_ driver.Value, err error) {
+	return ValueJSON(p)
+}
+
+func (p *LegalPerson) Scan(src interface{}) error {
+	o := LegalPerson{}
+	if err := ScanJSON(src, &o); err != nil {
+		return err
+	}
+
+	*p = o
+	return nil
+}
+
+func (p *LegalPerson) Value() (_ driver.Value, err error) {
+	return ValueJSON(p)
+}
+
+func (a *Address) Scan(src interface{}) error {
+	o := Address{}
+	if err := ScanJSON(src, &o); err != nil {
+		return err
+	}
+
+	*a = o
+	return nil
+}
+
+func (a *Address) Value() (_ driver.Value, err error) {
+	return ValueJSON(a)
+}
+
+func ScanJSON(src, dst interface{}) error {
+	// Convert src into a byte array to unmarshal json data
+	var source []byte
+	switch t := src.(type) {
+	case []byte:
+		source = t
+	case nil:
+		return nil
+	default:
+		return fmt.Errorf("incompatible type to unmarshal json: %T", t)
+	}
+
+	if err := json.Unmarshal(source, dst); err != nil {
+		return err
+	}
+	return nil
+}
+
+func ValueJSON(obj interface{}) (_ driver.Value, err error) {
+	// Store null if obj is is nil
+	if obj == nil {
+		return nil, nil
+	}
+
+	// Store JSON as a BLOB for this type
+	var data []byte
+	if data, err = json.Marshal(obj); err != nil {
+		return nil, err
+	}
+	return driver.Value(data), nil
+}

--- a/pkg/ivms101/db_test.go
+++ b/pkg/ivms101/db_test.go
@@ -1,0 +1,95 @@
+package ivms101_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trisacrypto/trisa/pkg/ivms101"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestIVMS101Database(t *testing.T) {
+
+	t.Run("IdentityPayload", func(t *testing.T) {
+		ip := &ivms101.IdentityPayload{}
+		err := loadFixture("testdata/identity_payload.json", ip)
+		require.NoError(t, err, "could not load identity payload fixture")
+
+		value, err := ip.Value()
+		require.NoError(t, err, "could not fetch value for identity payload")
+
+		cp := &ivms101.IdentityPayload{}
+		err = cp.Scan(value)
+		require.NoError(t, err, "could not scan value into identity payload")
+		require.True(t, proto.Equal(ip, cp), "loaded value not equal to copied value")
+	})
+
+	t.Run("Person", func(t *testing.T) {
+		ip := &ivms101.Person{}
+		err := loadFixture("testdata/person_legal_person.json", ip)
+		require.NoError(t, err, "could not load legal person fixture")
+
+		value, err := ip.Value()
+		require.NoError(t, err, "could not fetch value for person")
+
+		cp := &ivms101.Person{}
+		err = cp.Scan(value)
+		require.NoError(t, err, "could not scan value into person")
+		require.True(t, proto.Equal(ip, cp), "loaded value not equal to copied value")
+	})
+
+	t.Run("LegalPerson", func(t *testing.T) {
+		ip := &ivms101.LegalPerson{}
+		err := loadFixture("testdata/legal_person.json", ip)
+		require.NoError(t, err, "could not load legal person fixture")
+
+		value, err := ip.Value()
+		require.NoError(t, err, "could not fetch value for legal person")
+
+		cp := &ivms101.LegalPerson{}
+		err = cp.Scan(value)
+		require.NoError(t, err, "could not scan value into legal person")
+		require.True(t, proto.Equal(ip, cp), "loaded value not equal to copied value")
+	})
+
+	t.Run("NaturalPerson", func(t *testing.T) {
+		ip := &ivms101.NaturalPerson{}
+		err := loadFixture("testdata/natural_person.json", ip)
+		require.NoError(t, err, "could not load natural person fixture")
+
+		value, err := ip.Value()
+		require.NoError(t, err, "could not fetch value for natural person")
+
+		cp := &ivms101.NaturalPerson{}
+		err = cp.Scan(value)
+		require.NoError(t, err, "could not scan value into natural person")
+
+		require.True(t, proto.Equal(ip, cp), "loaded value not equal to copied value")
+	})
+
+	t.Run("Address", func(t *testing.T) {
+		ip := &ivms101.Address{}
+		err := loadFixture("testdata/address.json", ip)
+		require.NoError(t, err, "could not load address fixture")
+
+		value, err := ip.Value()
+		require.NoError(t, err, "could not fetch value for address")
+
+		cp := &ivms101.Address{}
+		err = cp.Scan(value)
+		require.NoError(t, err, "could not scan value into address")
+		require.True(t, proto.Equal(ip, cp), "loaded value not equal to copied value")
+	})
+}
+
+func loadFixture(path string, obj interface{}) (err error) {
+	var f *os.File
+	if f, err = os.Open(path); err != nil {
+		return err
+	}
+	defer f.Close()
+
+	return json.NewDecoder(f).Decode(obj)
+}

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -8,10 +8,10 @@ import "fmt"
 // Version component constants for the current build.
 const (
 	VersionMajor         = 0
-	VersionMinor         = 3
-	VersionPatch         = 4
+	VersionMinor         = 5
+	VersionPatch         = 0
 	VersionReleaseLevel  = "v1beta1"
-	VersionReleaseNumber = 8
+	VersionReleaseNumber = 10
 )
 
 // Version returns the semantic version for the current build.


### PR DESCRIPTION
Adds `Scanner` and `Valuer` interface methods to the `IdentityPayload`, `Person`, `LegalPerson`, `NaturalPerson`, and `Address` IVMS101 structs. These methods store these structs as JSON bytes data suitable for a JSON or BLOB field in the database. 