### PR TITLE
Implement the Signer interface for RSA crypto

### DIFF
--- a/pkg/trisa/crypto/crypto.go
+++ b/pkg/trisa/crypto/crypto.go
@@ -25,7 +25,7 @@ type Cipher interface {
 	EncryptionAlgorithm() string
 }
 
-// Signer creates or verifies HMAC signatures. This interface wraps multiple hmac
+// Signer creates or verifies signatures. This interface wraps multiple
 // algorithms that must be identified in the TRISA protocol.
 type Signer interface {
 	Sign(data []byte) (signature []byte, err error)

--- a/pkg/trisa/crypto/rsaoeap/rsaoeap_test.go
+++ b/pkg/trisa/crypto/rsaoeap/rsaoeap_test.go
@@ -6,34 +6,50 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/trisacrypto/trisa/pkg/trisa/crypto"
 	"github.com/trisacrypto/trisa/pkg/trisa/crypto/rsaoeap"
 )
 
 func TestRSA(t *testing.T) {
+	// Generate a random key
 	priv, err := rsa.GenerateKey(rand.Reader, 4096)
 	require.NoError(t, err)
 
-	plaintext := []byte("for your eyes only -- classified")
+	// Test data
+	plaintext := []byte("for your eyes only -- classified") // to encrypt
+	data := []byte("trust, but verify.")                    // to sign
+	dataWrong := []byte("trust only after verification.")   // to fail verification
 
 	// Cipher only takes RSA keys
 	_, err = rsaoeap.New("foo")
-	require.Error(t, err)
+	require.ErrorContains(t, err, "could not create RSA cipher from", "unexpected or no error")
 
-	// Encrypt using a new cipher with just the public key
-	var cipher crypto.Cipher
-	cipher, err = rsaoeap.New(&priv.PublicKey)
+	// RSA with public key only
+	pubRSA, err := rsaoeap.New(&priv.PublicKey)
 	require.NoError(t, err)
 
-	ciphertext, err := cipher.Encrypt(plaintext)
+	// RSA with private and public keys
+	privRSA, err := rsaoeap.New(priv)
+	require.NoError(t, err)
+
+	// Encrypt using a new pubRSA with just the public key
+	ciphertext, err := pubRSA.Encrypt(plaintext)
 	require.NoError(t, err)
 
 	// Decrypt using a new cipher with both public and private key
-	var decoder crypto.Cipher
-	decoder, err = rsaoeap.New(priv)
-	require.NoError(t, err)
-
-	decoded, err := decoder.Decrypt(ciphertext)
+	decoded, err := privRSA.Decrypt(ciphertext)
 	require.NoError(t, err)
 	require.Equal(t, plaintext, decoded)
+
+	// Sign using the private key
+	signature, err := privRSA.Sign(data)
+	require.NoError(t, err, "could not sign message")
+	require.NotNil(t, signature, "expected a signature")
+
+	// Verify using just the public key
+	err = pubRSA.Verify(data, signature)
+	require.NoError(t, err, "could not verify message")
+
+	// Error when verifying an unmatched data/signature pair
+	err = pubRSA.Verify(dataWrong, signature)
+	require.ErrorIs(t, err, rsa.ErrVerification, "message was mistakenly verified")
 }


### PR DESCRIPTION
Add the `Signer` interface to the `RSA` crypto interface and added sign/verify testing (modified the test already there because generating a random key takes a while).